### PR TITLE
Feature/use result filter python

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -73,6 +73,20 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
+    fn assert_result_eq<T, E>(result: Result<T, E>, expected: Result<T, E>)
+    where
+        T: PartialEq + std::fmt::Debug,
+        E: std::fmt::Debug + std::fmt::Display,
+    {
+        match (result, expected) {
+            (Ok(result_vec), Ok(expected_vec)) => assert_eq!(result_vec, expected_vec),
+            (Err(result_err), Err(expected_err)) => {
+                assert_eq!(result_err.to_string(), expected_err.to_string())
+            }
+            _ => panic!("Result and expected do not match"),
+        }
+    }
+
     #[test]
     fn test_filter_python_files() {
         let paths = vec![
@@ -84,13 +98,7 @@ mod tests {
         let expected: Result<Vec<PathBuf>, Box<dyn Error>> =
             Ok(vec![PathBuf::from("script.py"), PathBuf::from("test.py")]);
         let result = filter_python_files(&paths);
-        match (result, expected) {
-            (Ok(result_vec), Ok(expected_vec)) => assert_eq!(result_vec, expected_vec),
-            (Err(result_err), Err(expected_err)) => {
-                assert_eq!(result_err.to_string(), expected_err.to_string())
-            }
-            _ => panic!("Result and expected do not match"),
-        }
+        assert_result_eq(result, expected);
     }
 
     #[test]
@@ -102,13 +110,7 @@ mod tests {
         ];
         let expected: Result<Vec<PathBuf>, Box<dyn Error>> = Ok(vec![]);
         let result = filter_python_files(&paths);
-        match (result, expected) {
-            (Ok(result_vec), Ok(expected_vec)) => assert_eq!(result_vec, expected_vec),
-            (Err(result_err), Err(expected_err)) => {
-                assert_eq!(result_err.to_string(), expected_err.to_string())
-            }
-            _ => panic!("Result and expected do not match"),
-        }
+        assert_result_eq(result, expected);
     }
 
     #[test]
@@ -120,13 +122,7 @@ mod tests {
         ];
         let expected: Result<Vec<PathBuf>, Box<dyn Error>> = Ok(paths.clone());
         let result = filter_python_files(&paths);
-        match (result, expected) {
-            (Ok(result_vec), Ok(expected_vec)) => assert_eq!(result_vec, expected_vec),
-            (Err(result_err), Err(expected_err)) => {
-                assert_eq!(result_err.to_string(), expected_err.to_string())
-            }
-            _ => panic!("Result and expected do not match"),
-        }
+        assert_result_eq(result, expected);
     }
 
     #[test]

--- a/src/common.rs
+++ b/src/common.rs
@@ -88,6 +88,14 @@ mod tests {
     }
 
     #[test]
+    fn test_filter_python_files_empty_paths() {
+        let paths: Vec<PathBuf> = vec![];
+        let expected: Result<Vec<PathBuf>, Box<dyn Error>> = Err("No paths provided".into());
+        let result = filter_python_files(&paths);
+        assert_result_eq(result, expected);
+    }
+
+    #[test]
     fn test_filter_python_files() {
         let paths = vec![
             PathBuf::from("script.py"),

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,4 @@
+use std::error::Error;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -16,7 +17,11 @@ pub fn get_all_paths_in_directory(dir: &Path) -> Vec<PathBuf> {
     paths
 }
 
-pub fn filter_python_files(paths: &Vec<PathBuf>) -> Vec<PathBuf> {
+pub fn filter_python_files(paths: &Vec<PathBuf>) -> Result<Vec<PathBuf>, Box<dyn Error>> {
+    if paths.is_empty() {
+        return Err("No paths provided".into());
+    }
+
     let mut python_paths = Vec::new();
     for path in paths {
         if path.extension().and_then(|s| s.to_str()) != Some("py") {
@@ -24,7 +29,7 @@ pub fn filter_python_files(paths: &Vec<PathBuf>) -> Vec<PathBuf> {
         }
         python_paths.push(path.clone());
     }
-    python_paths
+    Ok(python_paths)
 }
 
 pub fn read_lines(path: &PathBuf) -> Vec<String> {
@@ -76,9 +81,16 @@ mod tests {
             PathBuf::from("module.rs"),
             PathBuf::from("test.py"),
         ];
-        let expected = vec![PathBuf::from("script.py"), PathBuf::from("test.py")];
+        let expected: Result<Vec<PathBuf>, Box<dyn Error>> =
+            Ok(vec![PathBuf::from("script.py"), PathBuf::from("test.py")]);
         let result = filter_python_files(&paths);
-        assert_eq!(result, expected);
+        match (result, expected) {
+            (Ok(result_vec), Ok(expected_vec)) => assert_eq!(result_vec, expected_vec),
+            (Err(result_err), Err(expected_err)) => {
+                assert_eq!(result_err.to_string(), expected_err.to_string())
+            }
+            _ => panic!("Result and expected do not match"),
+        }
     }
 
     #[test]
@@ -88,9 +100,15 @@ mod tests {
             PathBuf::from("module.rs"),
             PathBuf::from("Cargo.toml"),
         ];
-        let expected: Vec<PathBuf> = vec![];
+        let expected: Result<Vec<PathBuf>, Box<dyn Error>> = Ok(vec![]);
         let result = filter_python_files(&paths);
-        assert_eq!(result, expected);
+        match (result, expected) {
+            (Ok(result_vec), Ok(expected_vec)) => assert_eq!(result_vec, expected_vec),
+            (Err(result_err), Err(expected_err)) => {
+                assert_eq!(result_err.to_string(), expected_err.to_string())
+            }
+            _ => panic!("Result and expected do not match"),
+        }
     }
 
     #[test]
@@ -100,9 +118,15 @@ mod tests {
             PathBuf::from("script2.py"),
             PathBuf::from("script3.py"),
         ];
-        let expected = paths.clone();
+        let expected: Result<Vec<PathBuf>, Box<dyn Error>> = Ok(paths.clone());
         let result = filter_python_files(&paths);
-        assert_eq!(result, expected);
+        match (result, expected) {
+            (Ok(result_vec), Ok(expected_vec)) => assert_eq!(result_vec, expected_vec),
+            (Err(result_err), Err(expected_err)) => {
+                assert_eq!(result_err.to_string(), expected_err.to_string())
+            }
+            _ => panic!("Result and expected do not match"),
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,8 @@ struct Args {
 }
 
 // TODO: Handle errors correctly, maybe with std::io::Result
+// TODO: Update main() to return Result<(), Box<dyn std::error::Error>>
+//       to simplify error handling
 fn main() {
     let curr_dir: PathBuf = env::current_dir().unwrap();
     let mut path: PathBuf = PathBuf::from(&Args::parse().path);
@@ -55,7 +57,11 @@ fn main() {
         }
     } else {
         let paths: Vec<PathBuf> = get_all_paths_in_directory(&path);
-        let python_files: Vec<PathBuf> = filter_python_files(&paths);
+        // TODO: Use the ? operator to propagate errors and simplify the main code
+        let python_files: Vec<PathBuf> = filter_python_files(&paths).unwrap_or_else(|e| {
+            println!("An error occurred: {}", e);
+            vec![] // default value
+        });
         let mut max: u8 = 0;
         for path in python_files {
             let contents: Vec<String> = read_lines(&path);


### PR DESCRIPTION
## Description

I hear that it's generally considered good practice to make functions, including main(), return Result<> when there's a possibility of an error occurring during the function's execution.
I'm considering following the pattern for all the function and migrating them one by one. (It would be super helpful if you could work on some).

This pull request updates `filter_python_files` which receives paths and returns only paths of Python files.
- Update the function signature
- Add a test for empty input
- Update main() and tests to comply with the updated function signature

## Checklist

- [x] I have run `cargo fmt`
